### PR TITLE
Make issue extraction concurrent

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3329,6 +3329,7 @@ name = "twir_parser"
 version = "0.1.0"
 dependencies = [
  "clap",
+ "futures",
  "indicatif",
  "lychee-lib",
  "reqwest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ license = "MIT"
 
 [dependencies]
 clap = { version = "4.3.4", features = ["derive"] }
+futures = "0.3.28"
 indicatif = "0.17.5"
 lychee-lib = "0.13.0"
 reqwest = "0.11.18"


### PR DESCRIPTION
Since all issues are independent of one another,
we can use [`FuturesUnordered`](https://docs.rs/futures/latest/futures/stream/struct.FuturesUnordered.html)
to make issue search concurrent. This results in a nice speed bump.

We use a `Semaphore` to limit the concurrency to a maximum of
100 concurrent checks.
Note that we need to convert the `extract_link_and_title` and
`parse_page` methods to static members, as we'd otherwise run into
ownership issues with `self`. Fortunately, these methods were
independent of `self` anyway, so they should probably have been static
to begin with.

A similar optimization can be done for the lychee link check, but I'd
change that in a separate PR.