### PR TITLE
feat(ci): use off-the-shelf GitHub Action 👷

### DIFF
--- a/.github/workflows/build-binary.yml
+++ b/.github/workflows/build-binary.yml
@@ -50,31 +50,30 @@ jobs:
       - name: Build
         run: |
           cargo build --release --target ${{ matrix.target }}
-      - id: package-name
-        name: Cargo package name
-        run: |
-          cargo install cargo-get
-          package_name=$(cargo get --name)
-          echo "package-name=${package_name}" >> $GITHUB_OUTPUT
+      - name: Get package name
+        id: package-name
+        uses: nicolaiunrein/cargo-get@master
+        with:
+          flags: --name
       - name: Rename binary
         run: |
-          cp target/${{ matrix.target }}/release/${{ steps.package-name.outputs.package-name }} target/${{ matrix.target }}/release/${{ steps.package-name.outputs.package-name }}-${{ matrix.target }}
+          cp target/${{ matrix.target }}/release/${{ steps.package-name.outputs.metadata }} target/${{ matrix.target }}/release/${{ steps.package-name.outputs.metadata }}-${{ matrix.target }}
       - name: Checksum
         run: |
           cd target/${{ matrix.target }}/release
-          sha256sum ${{ steps.package-name.outputs.package-name }}-${{ matrix.target }} > ${{ steps.package-name.outputs.package-name }}-${{ matrix.target }}.sha256
+          sha256sum ${{ steps.package-name.outputs.metadata }}-${{ matrix.target }} > ${{ steps.package-name.outputs.metadata }}-${{ matrix.target }}.sha256
       - name: Upload artifacts
         uses: actions/upload-artifact@v3
         with:
-          name: ${{ steps.package-name.outputs.package-name }}-${{ matrix.target }}
+          name: ${{ steps.package-name.outputs.metadata }}-${{ matrix.target }}
           path: |
-            target/${{ matrix.target }}/release/${{ steps.package-name.outputs.package-name }}-${{ matrix.target }}
-            target/${{ matrix.target }}/release/${{ steps.package-name.outputs.package-name }}-${{ matrix.target }}.sha256
+            target/${{ matrix.target }}/release/${{ steps.package-name.outputs.metadata }}-${{ matrix.target }}
+            target/${{ matrix.target }}/release/${{ steps.package-name.outputs.metadata }}-${{ matrix.target }}.sha256
           if-no-files-found: error
       - if: github.event_name == 'release' && github.event.action == 'published'
         name: Upload assets
         uses: softprops/action-gh-release@v1
         with:
           files: |
-            target/${{ matrix.target }}/release/${{ steps.package-name.outputs.package-name }}-${{ matrix.target }}
-            target/${{ matrix.target }}/release/${{ steps.package-name.outputs.package-name }}-${{ matrix.target }}.sha256
+            target/${{ matrix.target }}/release/${{ steps.package-name.outputs.metadata }}-${{ matrix.target }}
+            target/${{ matrix.target }}/release/${{ steps.package-name.outputs.metadata }}-${{ matrix.target }}.sha256

--- a/.github/workflows/build-binary.yml
+++ b/.github/workflows/build-binary.yml
@@ -54,7 +54,7 @@ jobs:
         id: package-name
         uses: nicolaiunrein/cargo-get@master
         with:
-          flags: --name
+          subcommand: package.name
       - name: Rename binary
         run: |
           cp target/${{ matrix.target }}/release/${{ steps.package-name.outputs.metadata }} target/${{ matrix.target }}/release/${{ steps.package-name.outputs.metadata }}-${{ matrix.target }}


### PR DESCRIPTION
`cargo-get` now has a off-the-shelf GitHub Action (nicolaiunrein/cargo-get#5).
Using that will result in the removal of [manual work](https://github.com/vlad-onis/twir_parser/blob/d97d613635c231d955812bdcb59c13f995645b1b/.github/workflows/build-binary.yml#L56).
It can also lead to potential speed-ups (nicolaiunrein/cargo-get#8) and reducing the billing time of GitHub action.
